### PR TITLE
Add tests for KNN engine and HTTP routes

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,51 @@
+import sys
+import types
+import numpy as np
+from contextlib import contextmanager
+
+@contextmanager
+def patch_dependencies():
+    """Patch heavy dependencies used by knn_engine and app."""
+    st_mod = types.ModuleType('sentence_transformers')
+    class DummyModel:
+        def encode(self, term, normalize_embeddings=True):
+            mapping = {
+                'a': np.array([1.0, 0.0]),
+                'b': np.array([0.0, 1.0]),
+                'c': np.array([1.0, 1.0]),
+            }
+            return mapping.get(term, np.zeros(2))
+    def cos_sim(a, b):
+        b = np.atleast_2d(b)
+        sims = np.dot(b, a)
+        return np.array([sims])
+    st_mod.SentenceTransformer = lambda *a, **k: DummyModel()
+    st_mod.util = types.SimpleNamespace(cos_sim=cos_sim)
+    sys.modules['sentence_transformers'] = st_mod
+
+    sym_mod = types.ModuleType('symspellpy')
+    class DummySymSpell:
+        def __init__(self, *a, **k):
+            pass
+        def load_dictionary(self, *a, **k):
+            pass
+        def lookup(self, *a, **k):
+            return []
+    sym_mod.SymSpell = DummySymSpell
+    sym_mod.Verbosity = types.SimpleNamespace(CLOSEST=0)
+    sys.modules['symspellpy'] = sym_mod
+
+    py_mod = types.ModuleType('pymysql')
+    py_mod.cursors = types.SimpleNamespace(DictCursor=object)
+    py_mod.connect = lambda **k: None
+    sys.modules['pymysql'] = py_mod
+
+    import urllib.request
+    def noop(*a, **k):
+        return ('', None)
+    urllib.request.urlretrieve = noop
+
+    try:
+        yield
+    finally:
+        pass

--- a/tests/test_knn_engine.py
+++ b/tests/test_knn_engine.py
@@ -1,0 +1,44 @@
+import importlib
+import numpy as np
+import pytest
+
+from .conftest import patch_dependencies
+
+
+def load_module():
+    with patch_dependencies():
+        return importlib.import_module('knn_engine')
+
+
+def test_list_match():
+    ke = load_module()
+    assert ke._list_match(['a'], ['b', 'a'])
+    assert not ke._list_match(['x'], ['y'])
+
+
+def test_score(monkeypatch):
+    ke = load_module()
+
+    def fake_cov(st, adv):
+        return 0.5
+
+    monkeypatch.setattr(ke, '_coverage', fake_cov)
+    st = {'topics': ['a'], 'availability': ['mon'], 'language': ['en']}
+    adv = {'topics': ['b'], 'availability': ['mon'], 'language': ['es']}
+    expected = 0.5 * ke._WEIGHTS['topics'] + 1.0 * ke._WEIGHTS['availability'] + 0.0 * ke._WEIGHTS['language']
+    assert ke._score(st, adv) == expected
+
+
+def test_coverage(monkeypatch):
+    ke = load_module()
+
+    def fake_emb(term):
+        mapping = {'a': np.array([1, 0]), 'b': np.array([0, 1])}
+        return mapping[term]
+
+    monkeypatch.setattr(ke, '_emb', fake_emb)
+
+    student = ['a']
+    advisor = ['a', 'b']
+    cov = ke._coverage(student, advisor)
+    assert cov == 0.5

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -1,0 +1,60 @@
+import importlib
+import threading
+import time
+import requests
+from werkzeug.serving import make_server
+
+from .conftest import patch_dependencies
+
+class ServerThread(threading.Thread):
+    def __init__(self, app, host="127.0.0.1", port=5001):
+        super().__init__()
+        self.srv = make_server(host, port, app)
+        self.ctx = app.app_context()
+        self.ctx.push()
+        self.host = host
+        self.port = port
+
+    def run(self):
+        self.srv.serve_forever()
+
+    def shutdown(self):
+        self.srv.shutdown()
+        self.ctx.pop()
+
+
+def start_app():
+    with patch_dependencies():
+        app_mod = importlib.import_module('app')
+    return app_mod
+
+
+def test_match_endpoint():
+    app_mod = start_app()
+
+    # patch get_recommendations
+    app_mod.get_recommendations = lambda x: [{"advisorId": 1, "name": "a", "score": 0.9}]
+
+    server = ServerThread(app_mod.app)
+    server.start()
+    time.sleep(0.2)
+    try:
+        resp = requests.post(f"http://{server.host}:{server.port}/match/calculate", json={"studentId": 1})
+        assert resp.status_code == 200
+        assert resp.json() == [{"advisorId": 1, "name": "a", "score": 0.9}]
+    finally:
+        server.shutdown()
+        server.join()
+
+
+def test_match_bad_request():
+    app_mod = start_app()
+    server = ServerThread(app_mod.app)
+    server.start()
+    time.sleep(0.2)
+    try:
+        resp = requests.post(f"http://{server.host}:{server.port}/match/calculate", json={})
+        assert resp.status_code == 400
+    finally:
+        server.shutdown()
+        server.join()


### PR DESCRIPTION
## Summary
- add pytest fixtures to patch heavy libs
- unit tests for knn_engine helpers
- integration tests for `/match/calculate` using requests

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6879e0430d4883208cb53bb49a38a494