### PR TITLE
Add startup message when launching server

### DIFF
--- a/app.py
+++ b/app.py
@@ -134,4 +134,5 @@ def docs():
     """
 
 if __name__ == "__main__":
+    print("API lista y escuchando en http://localhost:8000")
     app.run(debug=True, port=8000)


### PR DESCRIPTION
## Summary
- print a message announcing the server URL before starting Flask

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6879e9e3fcc88320a6457dc66c354f83